### PR TITLE
Update appinsights.ts

### DIFF
--- a/src/lib/providers/appinsights/appinsights.ts
+++ b/src/lib/providers/appinsights/appinsights.ts
@@ -110,7 +110,7 @@ export class Angulartics2AppInsights {
    * @link https://github.com/Microsoft/ApplicationInsights-JS/blob/master/API-reference.md#trackevent
    */
   eventTrack(name: string, properties: { [name: string]: string }) {
-    appInsights.trackEvent(name, properties, this.measurements);
+    appInsights.trackEvent({name : name, properties : properties, measurements: this.measurements});
   }
 
   /**


### PR DESCRIPTION
https://github.com/Microsoft/ApplicationInsights-JS?tab=readme-ov-file#basic-usage

trackEvent is expecting an object and the provider is not setting the name properly.

appInsights.trackEvent({
  name: 'some event',
  properties: { // accepts any type
    prop1: 'string',
    prop2: 123.45,
    prop3: { nested: 'objects are okay too' }
  }
});

- **What kind of change does this PR introduce?**


- **What is the current behavior? Link to open issue?**


- **What is the new behavior?**
